### PR TITLE
JDOT release 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# JDOT version history
+
+# 0.5: Initial release
+
+## Features
+
+- round-trippable conversion
+- macros expansion and substitution by adding to `@macros` dict
+- importable python library
+- incremental/streaming decoding
+- jdot CLI tool
+   - pretty-printing with `-p` / `--pretty`
+- JDOT grammar in BNF
+- add Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## JSON with minimal punctuation, plus Macros
 
+[![PyPI](https://img.shields.io/pypi/v/jdot.svg)](https://pypi.org/project/jdot/)
 [![Test](https://github.com/saulpw/jdot/actions/workflows/main.yml/badge.svg)](https://github.com/saulpw/jdot/actions?query=workflow%3ATest)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/saulpw/jdot/blob/master/LICENSE.txt)
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@ from setuptools import setup
 setup(
         name="jdot",
         version="0.5",
+        description='JSON with minimal punctuation, plus Macros',
+        long_description=open('README.md').read(),
+        long_description_content_type='text/markdown',
+        author='Saul Pwanson',
+        url='https://github.com/saulpw/jdot',
         python_requires='>=3.7',
         py_modules=['jdot'],
         packages=["jdot"],


### PR DESCRIPTION
* Added CHANGELOG entry for 0.5
* Updated README with `<>`, `{}` explanations, PyPi badge, `pip3` install instructions, and `-p`.
* Added PyPI description metadata (this will not show up on PyPi until the next release of JDOT). 
* Reserved `jdot` entry on PyPi: https://pypi.org/project/jdot/

Note that some of the badge links will be broken until `saulpw/jsom` repo is renamed to `saulpw/jdot`!

README preview is here: https://github.com/anjakefala/jsom/tree/kef/0.5