### PR TITLE
Add argparse (ARG)

### DIFF
--- a/jdot/__main__.py
+++ b/jdot/__main__.py
@@ -2,6 +2,7 @@
 
 import sys
 import json
+import argparse
 
 from jdot import JdotCoder, JdotFormatter
 
@@ -38,95 +39,145 @@ def iterobjs(d):
     else:
         yield d
 
+def argparser():
+
+    parser = argparse.ArgumentParser(description='jdot')
+    inputs = parser.add_mutually_exclusive_group(required=False)
+    inputs.add_argument('-d', '--in-jdot', dest='in_jdot', type=str, required=False)
+    inputs.add_argument('-e', '-n', '--in-json', dest='in_json', type=str, required=False)
+    out_format = parser.add_mutually_exclusive_group(required=False)
+    out_format.add_argument(
+        '-j',
+        '--out-json',
+        dest='out_json',
+        action='store_true',
+        default=True,
+        required=False,
+    )
+    out_format.add_argument(
+        '-m', '--out-jdot', dest='out_json', action='store_false', required=False
+    )
+    parser.add_argument('--debug', action='store_true', default=False, required=False)
+    format_options = parser.add_argument_group('Format options')
+    format_options.add_argument(
+        '-p',
+        '--pretty',
+        dest='pretty_print',
+        action='store_true',
+        default=False,
+        required=False,
+    )
+    format_options.add_argument(
+        '--indent',
+        type=int,
+        default=4,
+        required=False,
+        help='number of spaces to indent in output (defaults to 4)',
+    )
+    format_options.add_argument(
+        '--indent-str',
+        type=str,
+        required=False,
+        help='specify which indentation character(s) to use.',
+    )
+    format_options.add_argument(
+        '--length-limit',
+        type=int,
+        required=False,
+        help='''
+        specify an approximate maximum number of characters that will be considered
+        for emitting a group of tokens on a single line.
+        ''',
+    )
+    format_options.add_argument(
+        '--value-limit',
+        type=int,
+        required=False,
+        help='''
+        specify the number of contained non-nested values that will be considered
+        for emitting a group of tokens on a single line.
+        ''',
+    )
+    format_options.add_argument(
+        '--strip-spaces',
+        type=str,
+        required=False,
+        help='''
+        strip_spaces specifies for which parenthesis types the space
+        immediately after the open paran or immediately before the close
+        paren will be stripped. For example, specifying strip_spaces='[]'
+        will emit lists as [1 2 3] instead of [ 1 2 3 ].
+    ''',
+    )
+    format_options.add_argument(
+        '--close-on-same-line',
+        action='store_true',
+        required=False,
+        help='''
+        place closing paren for multiline groups after the last enclosed value and
+        not on a newline
+        ''',
+    )
+    format_options.add_argument(
+        '--dedent-last-value',
+        action='store_true',
+        required=False,
+        help='''
+        whenever both the current group and the last inner group are wrapped, the
+        latter is not indented.  This works best when used in conjunction with dict
+        entries sorted by increasing size.
+    ''',
+    )
+    ordering = format_options.add_mutually_exclusive_group(required=False)
+    ordering.add_argument('--order-by-key', action='store_true', required=False)
+    ordering.add_argument('--order-by-size', action='store_true', required=False)
+
+    return parser
+
 
 def main():
-    i = 1
     jdotargs = []
     objs = []
     pretty_print = False
     format_options = {}
-    json_indent = 4
     sort_key = None
     j = JdotCoder()
 
-    out_json = True
+    argv = sys.argv[1:]
+    args, jdotargs = argparser().parse_known_args(argv)
 
-    while i < len(sys.argv):
-        arg = sys.argv[i]
-        i += 1
+    if args.in_jdot:
+        d = j.decode(read_arg(args.in_jdot))
+        objs.extend(iterobjs(d))
+    elif args.in_json:
+        d = json.loads(read_arg(args.in_json))
+        objs.extend(iterobjs(d))
+        args.out_json = False
 
-        if arg in ['-d', '--in-jdot']:
-            contents = read_arg(sys.argv[i])
-            d = j.decode(contents)
-            objs.extend(iterobjs(d))
+    format_options["indent_str"] = " " * args.indent
+    if args.indent_str:
+        format_options["indent_str"] = args.indent_str
+    format_options['length_limit'] = args.length_limit
+    format_options['value_limit'] = args.value_limit
+    format_options['strip_spaces'] = args.strip_spaces
+    format_options['close_on_same_line'] = args.close_on_same_line
+    format_options['dedent_last_value'] = args.dedent_last_value
+    if args.order_by_key:
+        sort_key = 'key'
+    elif args.order_by_size:
+        sort_key = 'size'
 
-            out_json = True
-            i += 1
-
-        elif arg in ['-e', '-n', '--in-json']:
-            contents = read_arg(sys.argv[i])
-            d = json.loads(contents)
-            objs.extend(iterobjs(d))
-
-            out_json = False
-            i += 1
-
-        elif arg in ['-j', '--out-json']:
-            out_json = True
-
-        elif arg in ['-m', '--out-jdot']:  # encode
-            out_json = False
-
-        elif arg in ['-p', '--pretty']:
-            pretty_print = True
-
-        elif arg in ['--indent']:
-            json_indent = int(sys.argv[i])
-            format_options['indent_str'] = ' '*json_indent
-            i += 1
-
-        elif arg in ['--indent-str']:
-            format_options['indent_str'] = sys.argv[i]
-            i += 1
-
-        elif arg in ['--length-limit']:
-            format_options['length_limit'] = int(sys.argv[i])
-            i += 1
-
-        elif arg in ['--value-limit']:
-            format_options['value_limit'] = int(sys.argv[i])
-            i += 1
-
-        elif arg in ['--strip-spaces']:
-            format_options['strip_spaces'] = sys.argv[i]
-            i += 1
-
-        elif arg in ['--close-on-same-line']:
-            format_options['close_on_same_line'] = True
-
-        elif arg in ['--dedent-last-value']:
-            format_options['dedent_last_value'] = True
-
-        elif arg in ['--order-by-key']:
-            sort_key = 'key'
-
-        elif arg in ['--order-by-size']:
-            sort_key = 'size'
-
-        elif arg in ['--debug']:
-            j.options['debug'] = True
-
-        else:
-            jdotargs.append(arg)
+    if args.debug:
+        j.options['debug'] = True
 
     if jdotargs:
         d = j.decode(' '.join(jdotargs))
         objs.extend(iterobjs(d))
 
     if objs:
-        if out_json:
-            if pretty_print:
-                indent = json_indent
+        if args.out_json:
+            if args.pretty_print:
+                indent = args.indent
             else:
                 indent = None
             print(json.dumps(
@@ -135,7 +186,7 @@ def main():
                 sort_keys=(sort_key == 'key'),
                 indent=indent))
         else:
-            if pretty_print:
+            if args.pretty_print:
                 formatter = JdotFormatter(**format_options)
             else:
                 formatter = None


### PR DESCRIPTION
why did I do this...

I figured @saulpw wouldn't want to add an external dependency, so here is, I think, the correct-ish implementation for argparse for the `jdot` options.

